### PR TITLE
Add support for changing the open mode dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ The below example configurations are given for [lazy.nvim](https://github.com/fo
         -- Custom keybindings only applied within the TFM buffer
         -- Default: {}
         keybindings = {
-            ["<ESC>"] = "q"
+            ["<ESC>"] = "q",
+            -- override the open mode (i.e. vertical/horizontal split, new tab)
+            -- and open the selected files
+            ["<C-v>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.vsplit)<CR><CR>",
+            ["<C-x>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.split)<CR><CR>",
+            ["<C-t>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.tabedit)<CR><CR>",
         },
         -- Customise UI. The below options are the default
         ui = {

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Changes the selected file manager. This is not persistent so the change will be 
 
 - `file_manager` should be one of the supported TFMs listed at the top of the page
 
+### `set_next_open_mode(open_mode)`
+
+Changes the next mode with which to open/edit selected files. Can be run while the terminal window is open.
+
+- `open_mode` should be an option from the enum defined below.
+
 ### `enum OPEN_MODE`
 
 Enum to configure modes with which to open/edit selected files.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ The below example configurations are given for [lazy.nvim](https://github.com/fo
         -- Default: {}
         keybindings = {
             ["<ESC>"] = "q",
-            -- override the open mode (i.e. vertical/horizontal split, new tab)
-            -- and open the selected files
-            ["<C-v>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.vsplit)<CR><CR>",
-            ["<C-x>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.split)<CR><CR>",
-            ["<C-t>"] = "<C-\\><C-O>:lua require('tfm').next_open_mode(require('tfm').OPEN_MODE.tabedit)<CR><CR>",
+            -- Override the open mode (i.e. vertical/horizontal split, new tab)
+            -- Tip: you can add an extra `<CR>` to the end of these to immediately open the selected file(s) (assuming the TFM uses `enter` to finalise selection)
+            ["<C-v>"] = "<C-\\><C-O>:lua require('tfm').set_next_open_mode(require('tfm').OPEN_MODE.vsplit)<CR>",
+            ["<C-x>"] = "<C-\\><C-O>:lua require('tfm').set_next_open_mode(require('tfm').OPEN_MODE.split)<CR>",
+            ["<C-t>"] = "<C-\\><C-O>:lua require('tfm').set_next_open_mode(require('tfm').OPEN_MODE.tabedit)<CR>",
         },
         -- Customise UI. The below options are the default
         ui = {

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The below example configurations are given for [lazy.nvim](https://github.com/fo
         {
             "<leader>mh",
             ":TfmSplit<CR>",
-            desc = "TFM - horizonal split",
+            desc = "TFM - horizontal split",
         },
         {
             "<leader>mv",
@@ -176,7 +176,7 @@ If you don't want to enable the commands, you can just use pure Lua keybindings:
                 local tfm = require("tfm")
                 tfm.open(nil, tfm.OPEN_MODE.split)
             end,
-            desc = "TFM - horizonal split",
+            desc = "TFM - horizontal split",
         },
         {
             "<leader>mv",
@@ -218,7 +218,7 @@ If you don't want to enable the commands, you can just use pure Lua keybindings:
 
 Feel free let me know how I can improve this plugin by opening an issue. PRs are also welcome.
 
-## Acknowlegements
+## Credit
 
 - [@kelly-lin](https://github.com/kelly-lin) for writing [ranger.nvim](https://github.com/kelly-lin/ranger.nvim)
 

--- a/lua/tfm.lua
+++ b/lua/tfm.lua
@@ -325,11 +325,9 @@ M.select_file_manager = function(file_manager)
     opts.file_manager = file_manager
 end
 
----Change next open mode
----Can be called by the user when on the terminal buffer to control how to
----open the next file
----@param open_mode OPEN_MODE|nil Open the next file(s) using a specific mode, e.g. "split", "vsplit", "tabedit"
-function M.next_open_mode(open_mode)
+---Set the next mode that selected file(s) will be opened with
+---@param open_mode OPEN_MODE|nil The next mode to open selected file(s) with
+function M.set_next_open_mode(open_mode)
     vim.b.tfm_next_open_mode = open_mode
 end
 

--- a/lua/tfm.lua
+++ b/lua/tfm.lua
@@ -302,6 +302,9 @@ function M.open(path_to_open, open_mode)
                 return
             end
 
+            -- get buffer vars before closing the terminal window
+            open_mode = vim.b.tfm_next_open_mode or open_mode
+
             vim.api.nvim_win_close(0, true)
             vim.api.nvim_set_current_win(last_win)
 
@@ -326,6 +329,14 @@ M.select_file_manager = function(file_manager)
     )
 
     opts.file_manager = file_manager
+end
+
+---Change next open mode
+---Can be called by the user when on the terminal buffer to control how to
+---open the next file
+---@param open_mode OPEN_MODE|nil Open the next file(s) using a specific mode, e.g. "split", "vsplit", "tabedit"
+function M.next_open_mode(open_mode)
+    vim.b.tfm_next_open_mode = open_mode
 end
 
 ---Optional setup to configure tfm.nvim.

--- a/lua/tfm.lua
+++ b/lua/tfm.lua
@@ -1,6 +1,5 @@
 local PATH_CACHE = vim.fn.stdpath("cache")
 local PATH_SELECTED_FILES = PATH_CACHE .. "/tfm_selected_files"
-local PATH_MODE_FILE = PATH_CACHE .. "/tfm_mode"
 
 local M = {}
 
@@ -215,7 +214,6 @@ end
 ---Clean up temporary files used to communicate between the terminal file manager and the plugin
 local function clean_up()
     vim.fn.delete(PATH_SELECTED_FILES)
-    vim.fn.delete(PATH_MODE_FILE)
 end
 
 ---Disable and replace netrw

--- a/lua/tfm.lua
+++ b/lua/tfm.lua
@@ -5,7 +5,7 @@ local M = {}
 
 ---@class FileManager
 ---@field cmd string command name
----@field set_file_chooser_ouput string flag to set the chosen files output file
+---@field set_file_chooser_output string flag to set the chosen files output file
 ---@field set_focused_file string flag to set the focused file
 
 ---Configurable user options.
@@ -36,27 +36,27 @@ M.OPEN_MODE = {
 M.FILE_MANAGERS = {
     ranger = {
         cmd = "ranger",
-        set_file_chooser_ouput = "--choosefiles",
+        set_file_chooser_output = "--choosefiles",
         set_focused_file = "--selectfile",
     },
     nnn = {
         cmd = "nnn",
-        set_file_chooser_ouput = "-p",
+        set_file_chooser_output = "-p",
         set_focused_file = "",
     },
     lf = {
         cmd = "lf",
-        set_file_chooser_ouput = "-selection-path",
+        set_file_chooser_output = "-selection-path",
         set_focused_file = "",
     },
     yazi = {
         cmd = "yazi",
-        set_file_chooser_ouput = "--chooser-file",
+        set_file_chooser_output = "--chooser-file",
         set_focused_file = "",
     },
     vifm = {
         cmd = "vifm",
-        set_file_chooser_ouput = "--choose-files",
+        set_file_chooser_output = "--choose-files",
         set_focused_file = "--select",
     },
 }
@@ -125,11 +125,8 @@ end
 ---@return string
 local function build_tfm_cmd(selected_manager, path_to_open)
     -- FILE CHOOSER MODE
-    local arg_file_chooser = string.format(
-        "%s %s",
-        selected_manager.set_file_chooser_ouput,
-        PATH_SELECTED_FILES
-    )
+    local arg_file_chooser =
+        string.format("%s %s", selected_manager.set_file_chooser_output, PATH_SELECTED_FILES)
 
     -- FILE TO BE FOCUSED
     -- Take the given path or fallback to the current file
@@ -146,8 +143,7 @@ local function build_tfm_cmd(selected_manager, path_to_open)
         file_to_focus = string.format('"%s"', file_to_focus)
     end
 
-    local arg_focus_file =
-        string.format("%s %s", selected_manager.set_focused_file, file_to_focus)
+    local arg_focus_file = string.format("%s %s", selected_manager.set_focused_file, file_to_focus)
 
     return string.format(
         "%s %s %s",
@@ -351,10 +347,7 @@ function M.setup(user_opts)
     if opts.enable_cmds then
         vim.cmd('command! Tfm lua require("tfm").open()')
         vim.cmd(
-            string.format(
-                'command! TfmSplit lua require("tfm").open(nil, "%s")',
-                M.OPEN_MODE.split
-            )
+            string.format('command! TfmSplit lua require("tfm").open(nil, "%s")', M.OPEN_MODE.split)
         )
         vim.cmd(
             string.format(


### PR DESCRIPTION
## Intro

Greetings, and nice fork you have here! In the past I used [rnvimr](https://github.com/kevinhwang91/rnvimr), and when I wanted to try out a new file manager other than ranger, tfm was one of the most flexible options I saw to be able to use it inside neovim.

## Dynamic open modes

Currently, with tfm.nvim, it is only possible to set the open mode at the moment the file manager is opened, and not later.

With rnvimr, it is possible to defer the open mode choice to the actual moment the selected file is being opened. [Each open mode then gets a specific keybind](https://github.com/kevinhwang91/rnvimr/blob/3c41af742a61caf74a9f83fb82b9ed03ef13b880/autoload/rnvimr.vim#L5-L8).

## Use case

The use case for wanting the ability to set the open mode later is simple. A user may be navigating a complex and deep directory structure, and only after reaching their desired file might they decide whether they want to replace the current buffer with it, open it in a new vertical/horizontal split, or open it in a new tab. With the current tfm.nvim version, they would have to close the terminal buffer, open it again with the desired open mode, and navigate back to the file. This could be cumbersome!

## Implementation

The code and associated suggestions in the README are self-explanatory. I wanted to shift more logic to the plugin to avoid such convoluted keymap sequences, but I didn't have any grand ideas that wouldn't make strong assumptions about a user's existing keymaps (e.g. what if a user doesn't open files with `<CR>` and/or uses a different sequence other than `<C-\\><C-O>` to be able to run commands in a term buffer?). Happy to hear other ideas here.

I also took the liberty to remove some related but dead code, which seem leftovers from the upstream repo. There's probably more that could be cleaned, but I didn't look further. I can also remove that specific commit if you find it to be inadequate for this PR.

## Demo

A `vsplit` is done at the end even though tfm was not called with the `vsplit` mode:

![rec](https://github.com/Rolv-Apneseth/tfm.nvim/assets/9000296/f6c53b55-17a8-4b30-96b5-c16b0a714ae6)